### PR TITLE
use stable version of sentry-auth-google

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://github.com/getsentry/sentry-auth-google/archive/master.zip
+https://github.com/getsentry/sentry-auth-google/archive/52020f577f587595fea55f5d05520f1473deaad1.zip


### PR DESCRIPTION
See: https://github.com/getsentry/sentry-auth-google/issues/23

MigratingIdentityId used in sentry-auth-google master is not supported yet in stable version of sentry.